### PR TITLE
fixed invalid index type Arial on line 86 dpad.py

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -3,4 +3,5 @@
 - [**Name:** Garima Choudhary, **email:** garima0224.be20@chitkara.edu.in] (https://www.github.com/GC2002)
 - [**Name:** Abdul Adhil PK, **email:** 1abduladhilpkpe3@gmail.com] (https://www.github.com/adhilcodes)
 - [**Name:** Pranjal Srivastava, **email:** pranjalsr.biz@gmail.com] (https://github.com/Dernyt-TPE)
+- [**Name:** Sairaj Kapdi, **email:** saikapdi11@gmail.com] (https://github.com/SairajK19)
 

--- a/dpad.py
+++ b/dpad.py
@@ -83,7 +83,8 @@ font_tuple= tk.font.families()
 font_family= tk.StringVar()
 font_box= ttk.Combobox(tool_bar, width=30, textvariable=font_family, state="readonly")
 font_box["values"]= font_tuple
-font_box.current(font_tuple.index("Arial"))
+# font_box.current(font_tuple.index("Arial"))
+font_box.current(font_tuple.index("fangsong ti"))
 font_box.grid(row=0,column=0,padx=5)
 
 


### PR DESCRIPTION
**On line 86 it gives the following error:**
Traceback (most recent call last):
  File "dpad.py", line 86, in <module>
    font_box.current(font_tuple.index("Arial"))
ValueError: tuple.index(x): x not in tuple

**There is no Arial font in the font_tuple variable**
('fangsong ti', 'fixed', 'clearlyu alternate glyphs', 'courier 10 pitch', 'open look glyph', 'bitstream charter', 'song ti', 'open look cursor', 'newspaper', 'clearlyu ligature', 'mincho', 'clearlyu devangari extra', 'clearlyu pua', 'clearlyu', 'clean', 'nil', 'clearlyu arabic', 'clearlyu devanagari', 'gothic', 'clearlyu arabic extra') 
I printed the above type and checked.

Have set the index value to "fangsong ti" the first item in the font tuple.

Thankyou
